### PR TITLE
Issues #54 #55

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,5 @@
 group 'com.epam.cme'
-version '2.1.0'
+version '2.1.1'
 
 apply plugin: 'java'
 

--- a/mbp-only/build.gradle
+++ b/mbp-only/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id "me.champeau.gradle.jmh" version "0.3.1"
 }
 group = 'com.epam.cme'
-version = '2.1.0'
+version = '2.1.1'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/mbp-with-mbo/build.gradle
+++ b/mbp-with-mbo/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.epam.cme'
-version = '2.1.0'
+version = '2.1.1'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/channel/LowLevelMdpChannel.java
+++ b/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/channel/LowLevelMdpChannel.java
@@ -72,6 +72,7 @@ public class LowLevelMdpChannel implements MdpChannel {
                        final int incrQueueSize,
                        final int rcvBufSize,
                        final int gapThreshold,
+                       final int maxNumberOfTCPAttempts,
                        final String tcpUsername,
                        final String tcpPassword,
                        final Map<FeedType, String> feedANetworkInterfaces,
@@ -111,7 +112,7 @@ public class LowLevelMdpChannel implements MdpChannel {
             TCPChannel tcpChannel = new MdpTCPChannel(connectionCfg);
             tcpMessageRequester = new MdpTCPMessageRequester<>(channelId, listeners, mdpMessageTypes, tcpChannel, tcpUsername, tcpPassword);
         }
-        this.channelController = new GapChannelController(listeners, target, targetForBuffered, recoveryManager, buffer, gapThreshold,
+        this.channelController = new GapChannelController(listeners, target, targetForBuffered, recoveryManager, buffer, gapThreshold, maxNumberOfTCPAttempts,
                 channelId, mdpMessageTypes, mboCycleHandler, mbpCycleHandler, scheduledExecutorService, tcpMessageRequester, mboIncrementMessageTemplateIds, mboSnapshotMessageTemplateIds);
         emptyBookConsumers.add(channelController);
         if (scheduledExecutorService != null) initChannelStateThread();

--- a/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/channel/MdpChannelBuilder.java
+++ b/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/channel/MdpChannelBuilder.java
@@ -16,6 +16,7 @@ import com.epam.cme.mdp3.ChannelListener;
 import com.epam.cme.mdp3.Feed;
 import com.epam.cme.mdp3.FeedType;
 import com.epam.cme.mdp3.MdpChannel;
+import com.epam.cme.mdp3.control.GapChannelController;
 import com.epam.cme.mdp3.core.cfg.Configuration;
 import com.epam.cme.mdp3.core.channel.MdpFeedWorker;
 import com.epam.cme.mdp3.core.channel.tcp.MdpTCPMessageRequester;
@@ -43,6 +44,7 @@ public class MdpChannelBuilder {
     private int rcvBufSize = MdpFeedWorker.RCV_BUFFER_SIZE;
     private String tcpUsername = MdpTCPMessageRequester.DEFAULT_USERNAME;
     private String tcpPassword = MdpTCPMessageRequester.DEFAULT_PASSWORD;
+    private int maxNumberOfTCPAttempts = GapChannelController.MAX_NUMBER_OF_TCP_ATTEMPTS;
     private boolean mboEnabled;
     private List<Integer> incrementMessageTemplateIds;
     private List<Integer> snapshotMessageTemplateIds;
@@ -101,6 +103,11 @@ public class MdpChannelBuilder {
         return this;
     }
 
+    public MdpChannelBuilder usingMaxNumberOfTCPAttempts(final int maxTcpAttempts) {
+    	this.maxNumberOfTCPAttempts = maxTcpAttempts;
+    	return this;
+    }
+    
     public MdpChannelBuilder setTcpUsername(final String tcpUsername) {
         this.tcpUsername = tcpUsername;
         return this;
@@ -131,7 +138,7 @@ public class MdpChannelBuilder {
             final Configuration cfg = new Configuration(this.cfgURI);
             final MdpMessageTypes mdpMessageTypes = new MdpMessageTypes(this.schemaURI);
             MdpChannel mdpChannel = new LowLevelMdpChannel(scheduler, cfg.getChannel(this.channelId), mdpMessageTypes,
-                     incrQueueSize, rcvBufSize, gapThreshold, tcpUsername, tcpPassword, feedANetworkInterfaces, feedBNetworkInterfaces, 
+                     incrQueueSize, rcvBufSize, gapThreshold, maxNumberOfTCPAttempts, tcpUsername, tcpPassword, feedANetworkInterfaces, feedBNetworkInterfaces, 
                      mboEnabled, incrementMessageTemplateIds, snapshotMessageTemplateIds);
             if (channelListener != null) mdpChannel.registerListener(channelListener);
             return mdpChannel;

--- a/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/control/GapChannelController.java
+++ b/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/control/GapChannelController.java
@@ -31,6 +31,7 @@ public class GapChannelController implements MdpChannelController, Consumer<MdpM
     public static final int MAX_NUMBER_OF_TCP_ATTEMPTS = 3;
     private final Lock lock = new ReentrantLock();
     private final int gapThreshold;
+    private final int maxNumberOfTCPAttempts;
     private final Buffer<MdpPacket> buffer;
     private final SnapshotRecoveryManager snapshotRecoveryManager;
     private final ChannelController target;
@@ -54,7 +55,7 @@ public class GapChannelController implements MdpChannelController, Consumer<MdpM
     
     public GapChannelController(List<ChannelListener> channelListeners, ChannelController target,
                                 ChannelController targetForBuffered, SnapshotRecoveryManager snapshotRecoveryManager,
-                                Buffer<MdpPacket> buffer, int gapThreshold, String channelId, MdpMessageTypes mdpMessageTypes,
+                                Buffer<MdpPacket> buffer, int gapThreshold, final int maxNumberOfTCPAttempts, String channelId, MdpMessageTypes mdpMessageTypes,
                                 SnapshotCycleHandler mboCycleHandler, SnapshotCycleHandler mbpCycleHandler,
                                 ScheduledExecutorService executor, TCPMessageRequester tcpMessageRequester,     
                                 List<Integer> mboIncrementMessageTemplateIds, List<Integer> mboSnapshotMessageTemplateIds) {
@@ -63,6 +64,7 @@ public class GapChannelController implements MdpChannelController, Consumer<MdpM
         this.snapshotRecoveryManager = snapshotRecoveryManager;
         this.target = target;
         this.gapThreshold = gapThreshold;
+        this.maxNumberOfTCPAttempts = maxNumberOfTCPAttempts;
         this.channelId = channelId;
         this.mdpMessageTypes = mdpMessageTypes;
         this.mboCycleHandler = mboCycleHandler;
@@ -176,8 +178,9 @@ public class GapChannelController implements MdpChannelController, Consumer<MdpM
                         if(pkgSequence > (expectedSequence + gapThreshold)) {
                             switchState(ChannelState.OUTOFSYNC);
                             long amountOfLostMessages = (pkgSequence - 1) - expectedSequence;
-                            if(numberOfTCPAttempts < MAX_NUMBER_OF_TCP_ATTEMPTS && amountOfLostMessages < TCPMessageRequester.MAX_AVAILABLE_MESSAGES
+                            if(numberOfTCPAttempts < maxNumberOfTCPAttempts && amountOfLostMessages < TCPMessageRequester.MAX_AVAILABLE_MESSAGES
                                     && tcpRecoveryProcessor != null && executor != null) {
+                            	log.trace("TCP Replay request gap {}:{} TCP Attempts: {}", expectedSequence, (pkgSequence-1), numberOfTCPAttempts);
                                 tcpRecoveryProcessor.setBeginSeqNo(expectedSequence);
                                 tcpRecoveryProcessor.setEndSeqNo(pkgSequence - 1);
                                 executor.execute(tcpRecoveryProcessor);
@@ -294,6 +297,7 @@ public class GapChannelController implements MdpChannelController, Consumer<MdpM
                         lock.lock();
                         switchState(ChannelState.SYNC);
                         processMessagesFromBuffer(feedContext);
+                        numberOfTCPAttempts = 0;
                     } finally {
                         lock.unlock();
                     }

--- a/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/control/GapChannelController.java
+++ b/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/control/GapChannelController.java
@@ -180,7 +180,9 @@ public class GapChannelController implements MdpChannelController, Consumer<MdpM
                             long amountOfLostMessages = (pkgSequence - 1) - expectedSequence;
                             if(numberOfTCPAttempts < maxNumberOfTCPAttempts && amountOfLostMessages < TCPMessageRequester.MAX_AVAILABLE_MESSAGES
                                     && tcpRecoveryProcessor != null && executor != null) {
-                            	log.trace("TCP Replay request gap {}:{} TCP Attempts: {}", expectedSequence, (pkgSequence-1), numberOfTCPAttempts);
+                                if(log.isTraceEnabled()) {
+                                    log.trace("TCP Replay request gap {}:{} TCP Attempts: {}", expectedSequence, (pkgSequence-1), numberOfTCPAttempts);
+                                }
                                 tcpRecoveryProcessor.setBeginSeqNo(expectedSequence);
                                 tcpRecoveryProcessor.setEndSeqNo(pkgSequence - 1);
                                 executor.execute(tcpRecoveryProcessor);

--- a/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/control/MDPOffHeapBuffer.java
+++ b/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/control/MDPOffHeapBuffer.java
@@ -44,7 +44,7 @@ public class MDPOffHeapBuffer implements Buffer<MdpPacket> {
 
     @Override
     public synchronized void add(MdpPacket entity) {
-    	if (!isPacketEmpty(entity) && msgSeqNums.contains(entity.getMsgSeqNum())) {
+    	if (msgSeqNums.contains(entity.getMsgSeqNum())) {
     		return;
     	}
     	msgSeqNums.add(entity.getMsgSeqNum());

--- a/mbp-with-mbo/src/test/java/com/epam/cme/mdp3/test/control/BufferTest.java
+++ b/mbp-with-mbo/src/test/java/com/epam/cme/mdp3/test/control/BufferTest.java
@@ -31,6 +31,22 @@ public class BufferTest {
     }
 
     @Test
+    public void elementsMustNotDuplicateSequence(){
+        MDPOffHeapBuffer buffer = new MDPOffHeapBuffer(5);
+        MdpPacket n1 = MdpPacket.instance(); n1.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(1));
+        MdpPacket n2 = MdpPacket.instance(); n2.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(1));
+        MdpPacket n3 = MdpPacket.instance(); n3.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(2));
+        buffer.add(n1);
+        buffer.add(n2);
+        buffer.add(n3);
+        for (int i = 1; i <= 2; i++) {
+            MdpPacket nextPacket = buffer.remove();
+            assertEquals(i, nextPacket.getMsgSeqNum());
+        }
+        assertNull(buffer.remove());
+    }
+
+    @Test
     public void bufferMustCopyDataFromObject(){
         MDPOffHeapBuffer buffer = new MDPOffHeapBuffer(3);
         MdpPacket packet = MdpPacket.instance();

--- a/mbp-with-mbo/src/test/java/com/epam/cme/mdp3/test/control/GapChannelControllerTest.java
+++ b/mbp-with-mbo/src/test/java/com/epam/cme/mdp3/test/control/GapChannelControllerTest.java
@@ -45,7 +45,7 @@ public class GapChannelControllerTest {
         ChannelController targetForBuffered = new BufferedMessageRouter(testChannelId, instrumentManager, mdpMessageTypes,
                 mboChannelListeners, mboSnapshotCycleHandler, new TestInstrumentObserver(testChannelId), Collections.emptyList(), null, null);
         gapChannelController = new GapChannelController(mboChannelListeners, testChannelController, targetForBuffered,
-                testRecoveryManager, buffer, 0, testChannelId, mdpMessageTypes, mboSnapshotCycleHandler, mboSnapshotCycleHandler,null, null, null, null);
+                testRecoveryManager, buffer, 0, GapChannelController.MAX_NUMBER_OF_TCP_ATTEMPTS, testChannelId, mdpMessageTypes, mboSnapshotCycleHandler, mboSnapshotCycleHandler,null, null, null, null);
 
     }
 
@@ -163,7 +163,7 @@ public class GapChannelControllerTest {
         testRecoveryManager = new TestSnapshotRecoveryManager();
         int gapThreshold = 3;
         OffHeapSnapshotCycleHandler cycleHandler = new OffHeapSnapshotCycleHandler();
-        gapChannelController = new GapChannelController(Collections.singletonList(testChannelListener), testChannelController, testChannelController, testRecoveryManager, buffer, gapThreshold, testChannelId, mdpMessageTypes, cycleHandler, cycleHandler, null, null, null, null);
+        gapChannelController = new GapChannelController(Collections.singletonList(testChannelListener), testChannelController, testChannelController, testRecoveryManager, buffer, gapThreshold, GapChannelController.MAX_NUMBER_OF_TCP_ATTEMPTS, testChannelId, mdpMessageTypes, cycleHandler, cycleHandler, null, null, null, null);
 
 
         int lastMsgSeqNumProcessed = 0;
@@ -197,7 +197,7 @@ public class GapChannelControllerTest {
         OffHeapSnapshotCycleHandler cycleHandler = new OffHeapSnapshotCycleHandler();
         ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
         gapChannelController = new GapChannelController(Collections.singletonList(testChannelListener),
-                testChannelController, testChannelController, testRecoveryManager, buffer, gapThreshold, testChannelId,
+                testChannelController, testChannelController, testRecoveryManager, buffer, gapThreshold, GapChannelController.MAX_NUMBER_OF_TCP_ATTEMPTS, testChannelId,
                 mdpMessageTypes, cycleHandler, cycleHandler, executorService, new TestTCPMessageRequester(), null, null);
 
 

--- a/mbp-with-mbo/src/test/java/com/epam/cme/mdp3/test/tcp/TCPMessageRequesterTest.java
+++ b/mbp-with-mbo/src/test/java/com/epam/cme/mdp3/test/tcp/TCPMessageRequesterTest.java
@@ -51,7 +51,7 @@ public class TCPMessageRequesterTest {
     @Test
     public void lostMessagesShouldBeReceivedFromListener() throws InterruptedException {
         long beginSeqNo = 1;
-        long endSeqNo = 3;
+        long endSeqNo = 4;
         new Thread(() -> messageRequester.askForLostMessages(beginSeqNo, endSeqNo, testTCPPacketListener)).start();
         tcpChannel.setNextMessageForReceiving(ModelUtils.getLogin(1));
         assertNotNull(nextPacket());


### PR DESCRIPTION
Update to allow the end user to set the max number of TCP attempts.
Update to reset the number of TCP attempts back to 0 after a successful attempt
Fix to the buffer to not allow duplicate seq numbers which can double memory requirements if using both feed A and B
Bump the minor version for changes.