### PR TITLE
remove the loop check method and replace with maintaining index

### DIFF
--- a/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/control/MDPOffHeapBuffer.java
+++ b/mbp-with-mbo/src/main/java/com/epam/cme/mdp3/control/MDPOffHeapBuffer.java
@@ -93,7 +93,7 @@ public class MDPOffHeapBuffer implements Buffer<MdpPacket> {
 
     private void sort(){
         //Arrays.sort is not the best variant here because it allocates TimSort class and array into it every time.
-        Arrays.sort(data, (o1, o2) -> {
+    	Arrays.sort(data, 0, full ? data.length : index, (o1, o2) -> {
             long sequence1 = o1.getMsgSeqNum();
             long sequence2 = o2.getMsgSeqNum();
             return Long.compare(sequence1, sequence2);

--- a/mbp-with-mbo/src/test/java/com/epam/cme/mdp3/test/control/BufferTest.java
+++ b/mbp-with-mbo/src/test/java/com/epam/cme/mdp3/test/control/BufferTest.java
@@ -82,7 +82,84 @@ public class BufferTest {
         }
         assertTrue(buffer.isEmpty());
     }
+    
+    @Test
+    public void outOfOrderAdditionAndRemoval(){
+        MDPOffHeapBuffer buffer = new MDPOffHeapBuffer(3);
+        MdpPacket n1 = MdpPacket.instance(); n1.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(1));
+        MdpPacket n2 = MdpPacket.instance(); n2.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(2));
+        MdpPacket n3 = MdpPacket.instance(); n3.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(3));
+        MdpPacket n4 = MdpPacket.instance(); n4.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(4));
+        MdpPacket n5 = MdpPacket.instance(); n5.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(5));
+        buffer.add(n3);
+        buffer.add(n1);
+        buffer.add(n5);
+        buffer.add(n2);
+        buffer.add(n4);
+        
+        assertFalse(buffer.isEmpty());
+        MdpPacket nextPacket = buffer.remove();
+        assertEquals(3, nextPacket.getMsgSeqNum());
+        nextPacket = buffer.remove();
+        assertEquals(4, nextPacket.getMsgSeqNum());
+        nextPacket = buffer.remove();
+        assertEquals(5, nextPacket.getMsgSeqNum());
+        
+        assertTrue(buffer.isEmpty());
+        
+        MdpPacket n6 = MdpPacket.instance(); n6.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(6));
+        MdpPacket n7 = MdpPacket.instance(); n7.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(7));
+        MdpPacket n8 = MdpPacket.instance(); n8.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(8));
+        MdpPacket n9 = MdpPacket.instance(); n9.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(9));
+        buffer.add(n7);
+        buffer.add(n8);
+        buffer.add(n6);
+        buffer.add(n9);
+        
+        nextPacket = buffer.remove();
+        assertEquals(7, nextPacket.getMsgSeqNum());
+        nextPacket = buffer.remove();
+        assertEquals(8, nextPacket.getMsgSeqNum());
+        nextPacket = buffer.remove();
+        assertEquals(9, nextPacket.getMsgSeqNum());
+        
+        assertTrue(buffer.isEmpty());        
+    }
+    
+    @Test
+    public void addAndRemoveHalfFull(){
+        MDPOffHeapBuffer buffer = new MDPOffHeapBuffer(5);
+        MdpPacket n1 = MdpPacket.instance(); n1.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(1));
+        MdpPacket n2 = MdpPacket.instance(); n2.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(2));
+        MdpPacket n3 = MdpPacket.instance(); n3.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(3));
+        MdpPacket n4 = MdpPacket.instance(); n4.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(4));
+        MdpPacket n5 = MdpPacket.instance(); n5.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(5));
+        MdpPacket n6 = MdpPacket.instance(); n6.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(6));
+        MdpPacket n7 = MdpPacket.instance(); n7.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(7));
+        MdpPacket n8 = MdpPacket.instance(); n8.wrapFromBuffer(ModelUtils.getMBOIncrementTestMessage(8));
+        buffer.add(n1);
+        buffer.add(n2);
+        buffer.add(n3);
+        buffer.add(n5);
+        buffer.add(n4);
+        
+        MdpPacket nextPacket = buffer.remove();
+        assertEquals(1, nextPacket.getMsgSeqNum());
 
+        nextPacket = buffer.remove();
+        assertEquals(2, nextPacket.getMsgSeqNum());
+        
+        buffer.add(n7);
+        buffer.add(n6);
+        buffer.add(n8);
+                
+        for (int x = 4; x <= 8; x++) {
+            nextPacket = buffer.remove();
+            assertEquals(x, nextPacket.getMsgSeqNum());        	
+        }
+        assertTrue(buffer.isEmpty());
+    }
+    
     @Test
     public void methodRemoveShouldReturnNullIfBufferIsEmpty(){
         MDPOffHeapBuffer buffer = new MDPOffHeapBuffer(3);
@@ -92,6 +169,4 @@ public class BufferTest {
         assertEquals(1, nextPacket.getMsgSeqNum());
         assertNull(buffer.remove());
     }
-
-
 }


### PR DESCRIPTION
Please review the changes I made closely. I have added 2 more tests also to cover off more edge cases with adding and remove data from the buffer to make sure things stay in order and are remove correctly according to msg seq number.